### PR TITLE
Upgrade to html-parse-stringify2 to solve some tag parsing issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "snabbdom": "^0.3.0"
   },
   "dependencies": {
-    "html-parse-stringify": "https://github.com/rayd/html-parse-stringify.git#7a9d6b4fb5eda23a7f8be0c5d5202da7b858b07e"
+    "html-parse-stringify2": "^1.1.0"
   }
 }

--- a/src/strings.js
+++ b/src/strings.js
@@ -1,4 +1,4 @@
-import parse from 'html-parse-stringify/lib/parse';
+import parse from 'html-parse-stringify2/lib/parse';
 import h from 'snabbdom/h';
 import { createTextVNode, transformName } from './utils';
 


### PR DESCRIPTION
Fixes a problem when trying to parse tag attributes with quotation marks in them. Really just upgrading to a new version of html-parse-stringify.
