### PR TITLE
Unescape HTML entities in text vnodes.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import VNode from 'snabbdom/vnode';
 
 export function createTextVNode(text) {
-    return VNode(undefined, undefined, undefined, text);
+    return VNode(undefined, undefined, undefined, unescape(text));
 }
 
 export function transformName(name) {
@@ -12,4 +12,16 @@ export function transformName(name) {
     // Handle properties that start with a -.
     const firstChar = name.charAt(0).toLowerCase();
     return `${firstChar}${name.substring(1)}`;
+}
+
+// Regex for matching HTML entities.
+const entityRegex = new RegExp('&[a-z0-9]+;', 'gi')
+// Element for setting innerHTML for transforming entities.
+const el = document.createElement('div');
+
+function unescape(text) {
+    return text.replace(entityRegex, (entity) => {
+        el.innerHTML = entity;
+        return el.textContent;
+    });
 }

--- a/test/tests/strings_test.js
+++ b/test/tests/strings_test.js
@@ -81,6 +81,12 @@ describe("#virtualizeString", () => {
         expect(virtualizeString("<div class='' />")).to.deep.equal(h('div'));
     });
 
+    it("should decode HTML entities, since VNodes just deal with text content", () => {
+        expect(virtualizeString("<div>&amp; is an ampersand! and &frac12; is 1/2!</div>")).to.deep.equal(
+            h('div', [ '& is an ampersand! and ½ is 1/2!' ])
+        );
+    });
+
     it("should call the 'create' hook for each VNode that was created after the virtualization process is complete", () => {
         const createSpy = sinon.spy();
         const vnodes = virtualizeString("<ul><li>One</li><li>Fish</li><li>Two</li><li>Fish</li></ul><p>Red Fish, Blue Fish</p>", {


### PR DESCRIPTION
Since `VNode`s could care less about HTML entities we should unescape them during the virtualization process. Otherwise when the text node is created from a `VNode` with text `&amp;`, you'll end up with just `&amp;` on the page, since DOM text nodes just contain the literal text that's put in them.
