### PR TITLE
Server side usage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prepublish": "npm run build",
     "build": "babel src -d lib",
     "watch": "npm run build -- --watch",
-    "test": "karma start test/karma.conf.js"
+    "test": "npm run build && karma start test/karma.conf.js && mocha test/nodejs_tests.js"
   },
   "main": "lib/index.js",
   "devDependencies": {
@@ -24,6 +24,7 @@
     "babel-loader": "^6.2.2",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.5.0",
+    "jsdom": "^9.4.2",
     "karma": "^0.13.19",
     "karma-chai": "^0.1.0",
     "karma-chai-sinon": "^0.1.5",

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3,22 +3,25 @@ import { createTextVNode, transformName } from './utils';
 import listeners from './event-listeners';
 
 export default function virtualizeNodes(element, options = {}) {
+
+    const context = options.context || document;
+
     if (!element) {
         return null;
     }
 
     const createdVNodes = [];
-    const vnode = convertNode(element, createdVNodes);
+    const vnode = convertNode(element, createdVNodes, context);
     options.hooks && options.hooks.create && createdVNodes.forEach((node) => { options.hooks.create(node); });
     return vnode;
 }
 
 
-function convertNode(element, createdVNodes) {
+function convertNode(element, createdVNodes, context) {
     // If our node is a text node, then we only want to set the `text` part of
     // the VNode.
     if (element.nodeType === Node.TEXT_NODE) {
-        const newNode = createTextVNode(element.textContent);
+        const newNode = createTextVNode(element.textContent, context);
         createdVNodes.push(newNode);
         return newNode
     }
@@ -68,7 +71,7 @@ function convertNode(element, createdVNodes) {
     if (children.length > 0) {
         childNodes = [];
         for (var i = 0; i < children.length; i++) {
-            childNodes.push(convertNode(children.item(i), createdVNodes));
+            childNodes.push(convertNode(children.item(i), createdVNodes, context));
         }
     }
     const newNode = h(element.tagName.toLowerCase(), data, childNodes);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -20,7 +20,7 @@ export default function virtualizeNodes(element, options = {}) {
 function convertNode(element, createdVNodes, context) {
     // If our node is a text node, then we only want to set the `text` part of
     // the VNode.
-    if (element.nodeType === Node.TEXT_NODE) {
+    if (element.nodeType === context.defaultView.Node.TEXT_NODE) {
         const newNode = createTextVNode(element.textContent, context);
         createdVNodes.push(newNode);
         return newNode

--- a/src/strings.js
+++ b/src/strings.js
@@ -3,6 +3,9 @@ import h from 'snabbdom/h';
 import { createTextVNode, transformName } from './utils';
 
 export default function(html, options = {}) {
+
+    const context = options.context || document;
+
     // If there's nothing here, return null;
     if (!html) {
         return null;
@@ -12,14 +15,14 @@ export default function(html, options = {}) {
     const createdVNodes = [];
 
     // Parse the string into the AST and convert to VNodes.
-    const vnodes = convertNodes(parse(html), createdVNodes);
+    const vnodes = convertNodes(parse(html), createdVNodes, context);
 
     let res;
     if (!vnodes) {
         // If there are no vnodes but there is string content, then the string
         // must be just text or at least invalid HTML that we should treat as
         // text (since the AST parser didn't find any well-formed HTML).
-        res = toVNode({ type: 'text', content: html }, createdVNodes);
+        res = toVNode({ type: 'text', content: html }, createdVNodes, context);
     }
     else if (vnodes.length === 1) {
         // If there's only one root node, just return it as opposed to an array.
@@ -35,22 +38,22 @@ export default function(html, options = {}) {
     return res;
 }
 
-function convertNodes(nodes, createdVNodes) {
+function convertNodes(nodes, createdVNodes, context) {
     if (nodes instanceof Array && nodes.length > 0) {
-        return nodes.map((node) => { return toVNode(node, createdVNodes); });
+        return nodes.map((node) => { return toVNode(node, createdVNodes, context); });
     }
     else {
         return undefined;
     }
 }
 
-function toVNode(node, createdVNodes) {
+function toVNode(node, createdVNodes, context) {
     let newNode;
     if (node.type === 'text') {
-        newNode = createTextVNode(node.content);
+        newNode = createTextVNode(node.content, context);
     }
     else {
-        newNode = h(node.name, buildVNodeData(node), convertNodes(node.children, createdVNodes));
+        newNode = h(node.name, buildVNodeData(node), convertNodes(node.children, createdVNodes, context));
     }
     createdVNodes.push(newNode);
     return newNode;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import VNode from 'snabbdom/vnode';
 
-export function createTextVNode(text) {
-    return VNode(undefined, undefined, undefined, unescape(text));
+export function createTextVNode(text, context) {
+    return VNode(undefined, undefined, undefined, unescape(text, context));
 }
 
 export function transformName(name) {
@@ -17,9 +17,13 @@ export function transformName(name) {
 // Regex for matching HTML entities.
 const entityRegex = new RegExp('&[a-z0-9]+;', 'gi')
 // Element for setting innerHTML for transforming entities.
-const el = document.createElement('div');
+let el = null;
 
-function unescape(text) {
+function unescape(text, context) {
+    // Create the element using the context if it doesn't exist.
+    if (!el) {
+        el = context.createElement('div');
+    }
     return text.replace(entityRegex, (entity) => {
         el.innerHTML = entity;
         return el.textContent;

--- a/test/nodejs_tests.js
+++ b/test/nodejs_tests.js
@@ -4,6 +4,9 @@ const virtualizeString = require('../strings').default;
 const virtualizeNodes = require('../nodes').default;
 const h = require('snabbdom/h');
 const jsdom = require('jsdom').jsdom;
+const extendVnode = require('./lib/helpers').extendVnode;
+const VNode = require('snabbdom/vnode');
+
 
 const opts = { context: (typeof document != 'undefined') ? document : jsdom('<html></html>') };
 
@@ -39,12 +42,12 @@ describe("In a nodejs environment", () => {
             const ul = doc.createElement('ul');
             ul.innerHTML = "<li>One</li><li>Fish</li><li>Two</li><li>Fish</li>";
             expect(virtualizeNodes(ul, opts)).to.deep.equal(
-                h('ul', [
-                    h('li', ['One']),
-                    h('li', ['Fish']),
-                    h('li', ['Two']),
-                    h('li', ['Fish'])
-                ])
+                extendVnode(h('ul', [
+                    extendVnode(h('li', [ extendVnode(VNode(undefined, undefined, undefined, 'One'), ul.childNodes[0].firstChild) ]), ul.childNodes[0]),
+                    extendVnode(h('li', [ extendVnode(VNode(undefined, undefined, undefined, 'Fish'), ul.childNodes[1].firstChild) ]), ul.childNodes[1]),
+                    extendVnode(h('li', [ extendVnode(VNode(undefined, undefined, undefined, 'Two'), ul.childNodes[2].firstChild) ]), ul.childNodes[2]),
+                    extendVnode(h('li', [ extendVnode(VNode(undefined, undefined, undefined, 'Fish'), ul.childNodes[3].firstChild) ]), ul.childNodes[3])
+                ]), ul)
             );
         });
 
@@ -52,7 +55,7 @@ describe("In a nodejs environment", () => {
             const div = doc.createElement('div');
             div.innerHTML = "&amp; is an ampersand! and &frac12; is 1/2!";
             expect(virtualizeNodes(div, opts)).to.deep.equal(
-                h('div', [ '& is an ampersand! and ½ is 1/2!' ])
+                extendVnode(h('div', [ extendVnode(VNode(undefined, undefined, undefined,'& is an ampersand! and ½ is 1/2!'), div.firstChild) ]), div)
             );
         });
     });

--- a/test/nodejs_tests.js
+++ b/test/nodejs_tests.js
@@ -1,0 +1,60 @@
+"use strict";
+const expect = require('chai').expect;
+const virtualizeString = require('../strings').default;
+const virtualizeNodes = require('../nodes').default;
+const h = require('snabbdom/h');
+const jsdom = require('jsdom').jsdom;
+
+const opts = { context: (typeof document != 'undefined') ? document : jsdom('<html></html>') };
+
+describe("In a nodejs environment", () => {
+    describe("virtualizeString", () => {
+        it("should convert nodes with children", () => {
+            expect(
+                virtualizeString("<ul><li>One</li><li>Fish</li><li>Two</li><li>Fish</li></ul>", opts)
+            ).to.deep.equal(
+                h('ul', [
+                    h('li', ['One']),
+                    h('li', ['Fish']),
+                    h('li', ['Two']),
+                    h('li', ['Fish'])
+                ])
+            );
+        });
+
+        it("should decode HTML entities, since VNodes just deal with text content", () => {
+            expect(virtualizeString("<div>&amp; is an ampersand! and &frac12; is 1/2!</div>", opts)).to.deep.equal(
+                h('div', [ '& is an ampersand! and ½ is 1/2!' ])
+            );
+        });
+    });
+
+    describe("virtualizeNodes", () => {
+        let doc;
+        beforeEach(() => {
+            doc = jsdom('<html></html>');
+        });
+
+        it("should convert nodes with children", () => {
+            const ul = doc.createElement('ul');
+            ul.innerHTML = "<li>One</li><li>Fish</li><li>Two</li><li>Fish</li>";
+            expect(virtualizeNodes(ul, opts)).to.deep.equal(
+                h('ul', [
+                    h('li', ['One']),
+                    h('li', ['Fish']),
+                    h('li', ['Two']),
+                    h('li', ['Fish'])
+                ])
+            );
+        });
+
+        it("should decode HTML entities, since VNodes just deal with text content", () => {
+            const div = doc.createElement('div');
+            div.innerHTML = "&amp; is an ampersand! and &frac12; is 1/2!";
+            expect(virtualizeNodes(div, opts)).to.deep.equal(
+                h('div', [ '& is an ampersand! and ½ is 1/2!' ])
+            );
+        });
+    });
+});
+


### PR DESCRIPTION
Another potential solution for #16. I prefer going this route as opposed to #17, as it allows the user of this library to specify an alternative "context" (i.e. document) and doesn't explicitly pull in jsdom as a dependency. This puts the burden of handling this case on the user of the library as opposed to building defaults into this library.

Usage in an isomorphic environment would be something like:

``` javascript
const jsdom = require('jsdom').jsdom;
const opts = { context: (typeof document != 'undefined') ? document : jsdom('<html></html>') };
const vnodes = virtualizeString("<ul><li>One</li><li>Fish</li><li>Two</li><li>Fish</li></ul>", opts);
```

In a purely server-side environment you could probably just do:

``` javascript
const jsdom = require('jsdom').jsdom;
const vnodes = virtualizeString("<ul><li>One</li><li>Fish</li><li>Two</li><li>Fish</li></ul>", {
  context: jsdom('<html></html>')
});
```

@wyqydsyq Do you think this would work for you? 
