### PR TITLE
Fix multiline classes

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -87,7 +87,9 @@ function getClasses(element) {
     const classes = {};
     if (className !== null && className.length > 0) {
         className.split(' ').forEach((className) => {
-            classes[className] = true;
+            if (className.trim().length) {
+                classes[className.trim()] = true;
+            }
         });
     }
     return classes;


### PR DESCRIPTION
Hi!

In case we have element like this:

```
<div class="
    class1
    class2
">
```

Virtual node classes will be wrong:
![red 2 5 2016-10-26 20-45-34](https://cloud.githubusercontent.com/assets/9027592/19737727/4425c292-9bbd-11e6-9a19-4aacb82ba771.png)

Empty string, line break and string with line break are not valid classes, and if we will patch element using this vdom, we will get:

![red 2 5 2016-10-26 20-47-56](https://cloud.githubusercontent.com/assets/9027592/19737778/7ed48c48-9bbd-11e6-8a93-101dc6b42648.png)

Some examples, why we have this result:
![red 2 5 2016-10-26 20-49-10](https://cloud.githubusercontent.com/assets/9027592/19737850/cce9bd68-9bbd-11e6-94a8-8816469a9e70.png)

![red 2 5 2016-10-26 20-50-34](https://cloud.githubusercontent.com/assets/9027592/19737867/dd5f1490-9bbd-11e6-946d-1774ad4dd12c.png)

![red 2 5 2016-10-26 20-51-05](https://cloud.githubusercontent.com/assets/9027592/19737885/f0e77d9a-9bbd-11e6-813a-93dc6add035b.png)

So first, what we can do is to add trim() of classes and to nod allow empty strings. This is what i offer in this PR.

Also we can change className parsing to classList reading.
