### PR TITLE
snabbdom version ~0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
-    "snabbdom": "~0",
+    "snabbdom": "~0.6.6",
     "socket.io": "1.4.6",
     "webpack": "^1.12.12"
   },
   "peerDependencies": {
-    "snabbdom": "~0"
+    "snabbdom": "~0.6.6"
   },
   "dependencies": {
     "html-parse-stringify2": "^1.2.1"

--- a/test/nodejs_tests.js
+++ b/test/nodejs_tests.js
@@ -2,10 +2,10 @@
 const expect = require('chai').expect;
 const virtualizeString = require('../strings').default;
 const virtualizeNodes = require('../nodes').default;
-const h = require('snabbdom/h');
+const { h } = require('snabbdom/h');
 const jsdom = require('jsdom').jsdom;
 const extendVnode = require('./lib/helpers').extendVnode;
-const VNode = require('snabbdom/vnode');
+const { vnode: VNode } = require('snabbdom/vnode');
 
 
 const opts = { context: (typeof document != 'undefined') ? document : jsdom('<html></html>') };


### PR DESCRIPTION
Hi. This fixes a case of broken dependency specification.

In the same opportunity, it also deals with a breaking change in snabbdom, regarding its exports.