### PR TITLE
Handle Control Characters in Attributes

### DIFF
--- a/test/tests/strings_test.js
+++ b/test/tests/strings_test.js
@@ -34,6 +34,18 @@ describe("#virtualizeString", () => {
             );
     });
 
+    it("should handle control characters in attribute values", () => {
+        const input = "<textarea placeholder='Hey Usher, \n\nAre these modals for real?!' class='placeholder-value'></textarea>";
+        expect(virtualizeString(input)).to.deep.equal(h('textarea', {
+            attrs: {
+                placeholder: 'Hey Usher, \n\nAre these modals for real?!'
+            },
+            class: {
+                'placeholder-value': true
+            }
+        }))
+    });
+
     it("should handle the special style attribute on nodes", () => {
         expect(virtualizeString("<div title='This is it!' style='display: none' />")).to.deep.equal(
             h('div', {


### PR DESCRIPTION
Currently, the following input...

```
<textarea placeholder='Hey Usher, \n\nAre these modals for real?!' class='placeholder-value'></textarea>
```

...results in an invalid `vnode`...

```
{
  "sel": "textarea",
  "data": {
    "attrs": {
      "placeholder": "Hey",
      "Usher": "Are",
      "these": "modals",
      "for": "real",
      "' class='": "placeholder-value"
    }
  }
}
```

**Hard Dependency** on a version bump after merging and releasing https://github.com/rayd/html-parse-stringify2/pull/12